### PR TITLE
Deploy a GitHub Pages (danytool) + HTTPS local (mkcert) en Windows

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,37 @@
+name: Deploy static content to Pages
+
+on:
+  push:
+    branches: ["danytool"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Certificados locales para desarrollo HTTPS (no versionar)
+dev/certs/*
+!dev/certs/.gitkeep

--- a/404.html
+++ b/404.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Redirigiendo…</title>
+  <meta http-equiv="refresh" content="0; url=./index.html" />
+  <script>
+    (function(){
+      try {
+        var repoBase = '/DAW-DANY-TOOL/';
+        // For GitHub Pages project sites, ensure we land on the index at the repo base
+        window.location.replace(repoBase);
+      } catch(e) {}
+    })();
+  </script>
+  <style>body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif;padding:2rem;text-align:center}</style>
+</head>
+<body>
+  <p>Redirigiendo a la página principal… Si no ocurre automáticamente, <a href="./index.html">haz clic aquí</a>.</p>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -37,3 +37,51 @@ python -m http.server 8080
 
 ## Licencia
 MIT — ver `LICENSE`.
+
+---
+
+## Deploy a GitHub Pages (rama danytool + Actions)
+Este repo está configurado para desplegarse automáticamente a **GitHub Pages** usando **GitHub Actions** desde la rama `danytool`.
+
+- Workflow: `.github/workflows/pages.yml` (sin build; sube la raíz `.` tal cual).
+- Disparadores: `push` a `danytool` y `workflow_dispatch` manual.
+- Permisos: `contents: read`, `pages: write`, `id-token: write`.
+- Concurrencia: grupo `pages` con cancelación en progreso.
+- Jobs: `build` (checkout + upload artifact) y `deploy` (deploy-pages con `environment: github-pages`).
+
+URL esperada (Pages):
+
+```
+https://613tdany-dotcom.github.io/DAW-DANY-TOOL/
+```
+
+Notas:
+- La primera vez, **Settings → Pages** suele mostrar "GitHub Actions" como origen automáticamente. Si el repositorio requiere confirmación manual, habilítalo allí una sola vez.
+- Las rutas son relativas, por lo que el sitio funciona bajo `/DAW-DANY-TOOL/`.
+
+## Desarrollo local HTTPS (Windows + Chrome + mkcert)
+Para que el micrófono funcione en desarrollo, usa HTTPS local sin dependencias de Node.
+
+1. Sigue la guía: `dev/README-local-https.md` (instalación de mkcert y generación de certificados).
+2. Ejecuta el servidor:
+
+```bash
+python dev/serve_https.py
+```
+
+3. Abre:
+
+```
+https://localhost:8443
+```
+
+Chrome en Windows utiliza el almacén de certificados del sistema, por lo que tras `mkcert -install` confiará en los certificados generados.
+
+### Saneamiento del remoto Git (quitar token)
+Si por accidente configuraste el remoto con un token embebido, cámbialo localmente a HTTPS sin credenciales:
+
+```bash
+git remote set-url origin https://github.com/613tdany-dotcom/DAW-DANY-TOOL.git
+```
+
+Este ajuste se hace **solo en tu máquina**. No se deben versionar tokens, claves ni ninguna información sensible.

--- a/dev/README-local-https.md
+++ b/dev/README-local-https.md
@@ -1,0 +1,65 @@
+# Desarrollo local con HTTPS en Windows (Chrome + mkcert)
+
+Este proyecto requiere HTTPS para habilitar permisos de micrófono en el navegador. A continuación tienes un flujo simple para Windows usando Python (sin Node) y certificados locales de confianza con [mkcert](https://github.com/FiloSottile/mkcert).
+
+## 1) Instalar mkcert
+
+- Con Chocolatey (recomendado):
+
+```powershell
+choco install mkcert -y
+```
+
+- O descarga el ejecutable desde la sección Releases:
+
+- https://github.com/FiloSottile/mkcert/releases
+
+Luego ejecuta una vez la instalación de la CA local:
+
+```powershell
+mkcert -install
+```
+
+Esto agrega una autoridad certificadora local al almacén del sistema (Windows). Chrome utilizará automáticamente este almacén, por lo que los certificados generados serán de confianza.
+
+## 2) Generar certificados para localhost
+
+Asegúrate de tener la carpeta `dev/certs/` (el repo incluye un `.gitkeep` para mantenerla vacía). Genera los certificados con:
+
+```powershell
+mkcert localhost 127.0.0.1 ::1 \
+  -cert-file dev/certs/localhost.pem \
+  -key-file dev/certs/localhost-key.pem
+```
+
+> Nota: Nunca subas estos certificados a git. Ya están ignorados por `.gitignore`.
+
+## 3) Ejecutar el servidor HTTPS local
+
+Desde la raíz del repo:
+
+```powershell
+python dev/serve_https.py
+```
+
+Abre en tu navegador:
+
+```
+https://localhost:8443
+```
+
+- El servidor sirve archivos desde la raíz del repositorio y muestra `index.html` por defecto.
+- Si es la primera vez, Chrome te pedirá permiso de micrófono. Acepta para poder grabar.
+
+## 4) Problemas comunes
+
+- "Certificados no encontrados": verifica que existen `dev/certs/localhost.pem` y `dev/certs/localhost-key.pem` y que ejecutaste `mkcert -install` antes de generarlos.
+- Si usas varias versiones de Python en Windows, también puedes probar:
+
+```powershell
+py -3 dev\serve_https.py
+```
+
+## 5) Limpieza de seguridad
+
+Si en algún momento compartes el repositorio, recuerda que los certificados locales están ignorados en git (`dev/certs/*`). No incluyas certificados ni claves privadas en commits.

--- a/dev/serve_https.py
+++ b/dev/serve_https.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+import http.server
+import socketserver
+import ssl
+import os
+import sys
+from pathlib import Path
+
+PORT = 8443
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CERT_FILE = REPO_ROOT / 'dev' / 'certs' / 'localhost.pem'
+KEY_FILE = REPO_ROOT / 'dev' / 'certs' / 'localhost-key.pem'
+
+class SimpleMimeHandler(http.server.SimpleHTTPRequestHandler):
+    # Serve from repository root
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=str(REPO_ROOT), **kwargs)
+
+    def guess_type(self, path):
+        _, ext = os.path.splitext(path.lower())
+        if ext == '.html':
+            return 'text/html; charset=utf-8'
+        if ext == '.css':
+            return 'text/css; charset=utf-8'
+        if ext == '.js':
+            # Widely compatible for browsers
+            return 'text/javascript; charset=utf-8'
+        if ext == '.json':
+            return 'application/json; charset=utf-8'
+        if ext == '.wav':
+            return 'audio/wav'
+        return 'application/octet-stream'
+
+    # Default to index.html for root paths
+    def do_GET(self):
+        if self.path in ('/', ''):
+            self.path = '/index.html'
+        return super().do_GET()
+
+
+def main():
+    if not CERT_FILE.exists() or not KEY_FILE.exists():
+        print('\n[!] Certificados no encontrados.')
+        print(f'    Esperado: {CERT_FILE}')
+        print(f'              {KEY_FILE}')
+        print('\nGenera certificados con mkcert (ver dev/README-local-https.md):')
+        print('    mkcert localhost 127.0.0.1 ::1 -cert-file dev/certs/localhost.pem -key-file dev/certs/localhost-key.pem')
+        sys.exit(1)
+
+    httpd = http.server.ThreadingHTTPServer(('0.0.0.0', PORT), SimpleMimeHandler)
+
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(certfile=str(CERT_FILE), keyfile=str(KEY_FILE))
+    httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+
+    print(f"\nSirviendo HTTPS desde: {REPO_ROOT}")
+    print(f"URL: https://localhost:{PORT}")
+    print("Presiona Ctrl+C para detener\n")
+
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\nDeteniendo servidor...")
+    finally:
+        httpd.server_close()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Este PR configura el despliegue automático a GitHub Pages desde la rama `danytool` y añade un servidor HTTPS local para desarrollo en Windows con `mkcert`, sin dependencias de Node.

Resumen (por qué):
- Publicar automáticamente en Pages al hacer push a `danytool` (evita pasos manuales y asegura HTTPS para micrófono en producción).
- Habilitar desarrollo local con HTTPS de confianza en Windows + Chrome usando Python y `mkcert` (permite probar la grabación).
- Evitar versionar certificados locales y documentar saneamiento del remoto para no incluir tokens.

Cambios principales:
- .github/workflows/pages.yml: Workflow "Deploy static content to Pages" (push a `danytool` + `workflow_dispatch`; checkout + `upload-pages-artifact@v3` con `path: '.'`; deploy con `deploy-pages@v4`, env `github-pages`).
- dev/serve_https.py: Pequeño servidor HTTPS (puerto 8443) con MIME básico (.html, .css, .js, .json, .wav) sirviendo desde la raíz; usa certificados en `dev/certs/`.
- dev/README-local-https.md: Guía Windows (mkcert con Chocolatey o release, `mkcert -install`, generación de certs, ejecución `python dev/serve_https.py`, notas Chrome).
- .gitignore: Ignora `dev/certs/*` y mantiene carpeta con `dev/certs/.gitkeep`.
- README.md: Secciones nuevas para Pages + desarrollo local HTTPS y subsección de saneamiento del remoto (quitar token).
- 404.html (opcional): redirección mínima al index para evitar 404 en rutas.

URL esperada de producción:
- https://613tdany-dotcom.github.io/DAW-DANY-TOOL/

Notas:
- Si es la primera vez, en Settings → Pages debería quedar "GitHub Actions" como origen. Si GitHub solicita confirmación manual, basta con habilitarlo una sola vez.

Criterios de aceptación:
- [ ] Push a `danytool` dispara Actions y publica en Pages (verde).
- [ ] La URL de Pages carga `index.html` y permite micrófono bajo HTTPS.
- [ ] En Windows + Chrome, `python dev/serve_https.py` sirve `https://localhost:8443` (tras `mkcert -install`) y el micrófono funciona.
- [ ] `.gitignore` evita subir `dev/certs/*`.
- [ ] README actualizado con instrucciones y saneamiento del remoto.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/ebfecd36-cec0-4756-8712-d5b4bf00e0e3/task/7de2a0bb-2256-449a-89a8-9d739b14b550))